### PR TITLE
Parts: Fix notification light app hint

### DIFF
--- a/src/org/lineageos/lineageparts/notificationlight/NotificationLightSettings.java
+++ b/src/org/lineageos/lineageparts/notificationlight/NotificationLightSettings.java
@@ -269,6 +269,7 @@ public class NotificationLightSettings extends SettingsPreferenceFragment implem
         Context context = getActivity();
 
         if (!parsePackageList()) {
+            maybeDisplayApplicationHint(context);
             return;
         }
 
@@ -296,17 +297,22 @@ public class NotificationLightSettings extends SettingsPreferenceFragment implem
                 }
             }
 
-            /* Display a pref explaining how to add apps */
-            if (mApplicationPrefList.getPreferenceCount() == 0) {
-                String summary = getResources().getString(
-                        R.string.notification_light_no_apps_summary);
-                String useCustom = getResources().getString(
-                        R.string.notification_light_use_custom);
-                Preference pref = new Preference(context);
-                pref.setSummary(String.format(summary, useCustom));
-                pref.setEnabled(false);
-                mApplicationPrefList.addPreference(pref);
-            }
+            maybeDisplayApplicationHint(context);
+        }
+    }
+
+    private void maybeDisplayApplicationHint(Context context)
+    {
+        /* Display a pref explaining how to add apps */
+        if (mApplicationPrefList != null && mApplicationPrefList.getPreferenceCount() == 0) {
+            String summary = getResources().getString(
+                    R.string.notification_light_no_apps_summary);
+            String useCustom = getResources().getString(
+                    R.string.notification_light_use_custom);
+            Preference pref = new Preference(context);
+            pref.setSummary(String.format(summary, useCustom));
+            pref.setEnabled(false);
+            mApplicationPrefList.addPreference(pref);
         }
     }
 


### PR DESCRIPTION
* The old code doesn't work when the entry in the database is not
  available, because it will cause parsePackageList() to return false,
  resulting in no execution of the code taking care of displaying the hint
* Move the hint to a new function and call it at the appropriate places
  to display the hint when no entry to the database was ever made

Thanks to @mikeioannina for noticing the missing hint

Change-Id: Ie3fb39cfa7e7b04a3536f98e93e2168d7367961d