### PR TITLE
parts: Trust: better warnings management

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -722,7 +722,9 @@
     <string name="trust_feature_encryption_explain">Encrypting your device prevents access to your data when your phone is off or in recovery mode. This is particularly important if your phone is stolen, and prevents people from reading your messages, contacts, and other private information without the password.\nTo make the encryption more effective you need to set a secure lock screen.</string>
     <string name="trust_category_tools">Privacy</string>
     <string name="trust_notification_alerts_title">Security alerts</string>
-    <string name="trust_notifications_alerts_summary">Display notifications when a security issue is found</string>
+    <string name="trust_warnings_alerts_intro">You can select the security issues you want to be warned about. For your safety, it is recommended to enable all alerts</string>
+    <string name="trust_warnings_selinux">SELinux status</string>
+    <string name="trust_warnings_keys">Build signature</string>
     <string name="trust_onboarding_title">Say hello to Trust</string>
     <string name="trust_onboarding_description">Trust helps you keep your device secure and protects your privacy.\nThe Trust icon will show up to help you by checking the security of the contents</string>
     <string name="trust_onboarding_learn_more">Learn more</string>

--- a/res/xml/trust_preferences.xml
+++ b/res/xml/trust_preferences.xml
@@ -56,15 +56,24 @@
             android:entryValues="@array/sms_security_check_limit_values"
             android:summary="@string/sms_security_check_limit_summary"
             android:title="@string/sms_security_check_limit_title" />
-        </PreferenceCategory>
+    </PreferenceCategory>
 
-        <PreferenceCategory
-            android:key="trust_category_alerts">
+    <PreferenceCategory
+        android:key="trust_category_warnings"
+        android:title="@string/trust_notification_alerts_title">
 
-        <lineageos.preference.LineageSecureSettingSwitchPreference
-            android:key="trust_notifications"
-            android:title="@string/trust_notification_alerts_title"
-            android:summary="@string/trust_notifications_alerts_summary"
+        <org.lineageos.lineageparts.widget.WallOfTextPreference
+            android:icon="@drawable/ic_info"
+            android:summary="@string/trust_warnings_alerts_intro" />
+
+        <SwitchPreference
+            android:key="trust_warning_selinux"
+            android:summary="@string/trust_warnings_selinux"
+            android:defaultValue="true" />
+
+        <SwitchPreference
+            android:key="trust_warning_keys"
+            android:summary="@string/trust_warnings_keys"
             android:defaultValue="true" />
     </PreferenceCategory>
 </PreferenceScreen>

--- a/src/org/lineageos/lineageparts/trust/TrustOnBoardingActivity.java
+++ b/src/org/lineageos/lineageparts/trust/TrustOnBoardingActivity.java
@@ -24,11 +24,14 @@ import android.widget.ImageView;
 import android.support.v7.app.AppCompatActivity;
 
 import lineageos.providers.LineageSettings;
+import lineageos.trust.TrustInterface;
 
 import org.lineageos.lineageparts.R;
 
 public class TrustOnBoardingActivity extends AppCompatActivity {
     private ImageView mImage;
+
+    private TrustInterface mInterface;
 
     @Override
     protected void onCreate(Bundle savedInstance) {
@@ -41,6 +44,8 @@ public class TrustOnBoardingActivity extends AppCompatActivity {
 
         learnMore.setOnClickListener(v -> openTrustSettings());
         dismiss.setOnClickListener(v -> onDismissClick());
+
+        mInterface = TrustInterface.getInstance(this);
 
         new Handler().postDelayed(this::showAnimation, 800);
     }
@@ -66,5 +71,7 @@ public class TrustOnBoardingActivity extends AppCompatActivity {
     private void setOnboardingCompleted() {
         LineageSettings.System.putInt(getContentResolver(),
                 LineageSettings.System.TRUST_INTERFACE_HINTED, 1);
+        // Run security check test now that the user is aware of what Trust is
+        mInterface.runTest();
     }
 }


### PR DESCRIPTION
Allow fine-tuned management of trust warnings,
the user is now able to disable specific warnings
instead of blocking everything.

Also show warnings (if any) when onBoarding is completed

Change-Id: I463279a8d99c1eeb2be6c0eeaf2e53e8f97ac160
Signed-off-by: Joey <joey@lineageos.org>