### PR TITLE
StatusBarSettings: Improve clock icon blacklist handling

### DIFF
--- a/src/org/lineageos/lineageparts/statusbar/StatusBarSettings.java
+++ b/src/org/lineageos/lineageparts/statusbar/StatusBarSettings.java
@@ -23,6 +23,7 @@ import android.support.v7.preference.PreferenceCategory;
 import android.support.v7.preference.PreferenceScreen;
 import android.support.v7.preference.Preference.OnPreferenceChangeListener;
 import android.text.format.DateFormat;
+import android.text.TextUtils;
 import android.view.View;
 
 import lineageos.preference.LineageSystemSettingListPreference;
@@ -95,7 +96,7 @@ public class StatusBarSettings extends SettingsPreferenceFragment
         final String curIconBlacklist = Settings.Secure.getString(getContext().getContentResolver(),
                 ICON_BLACKLIST);
 
-        if (curIconBlacklist != null && curIconBlacklist.contains("clock")) {
+        if (TextUtils.delimitedStringContains(curIconBlacklist, ',', "clock")) {
             getPreferenceScreen().removePreference(mStatusBarClockCategory);
         } else {
             getPreferenceScreen().addPreference(mStatusBarClockCategory);


### PR DESCRIPTION
* Apparently it is possible to have something with
  'clock' in name that will prevent clock settings
  from showing up. Splitting icon blacklist by ","
  fixes this issue.

Change-Id: Ia2a888401bc0c60b5c3afda07fbcde7c8b1b4309