### PR TITLE
LineageParts: Disable dark mode on light design

### DIFF
--- a/src/org/lineageos/lineageparts/style/StylePreferences.java
+++ b/src/org/lineageos/lineageparts/style/StylePreferences.java
@@ -48,7 +48,6 @@ import org.lineageos.lineageparts.style.util.UIUtils;
 import java.util.Arrays;
 import java.util.List;
 
-import lineageos.preference.LineageSystemSettingListPreference;
 import lineageos.providers.LineageSettings;
 import lineageos.style.StyleInterface;
 import lineageos.style.Suggestion;
@@ -61,6 +60,7 @@ public class StylePreferences extends SettingsPreferenceFragment {
 
     private Preference mStylePref;
     private Preference mAccentPref;
+    private Preference mDarkPref;
 
     private List<Accent> mAccents;
 
@@ -88,9 +88,9 @@ public class StylePreferences extends SettingsPreferenceFragment {
         mAccentPref.setOnPreferenceClickListener(this::onAccentClick);
         setupAccentPref();
 
-        LineageSystemSettingListPreference darkPref = (LineageSystemSettingListPreference)
-                findPreference("berry_dark_overlay");
-        darkPref.setOnPreferenceChangeListener(this::onDarkChange);
+        mDarkPref = findPreference("berry_dark_overlay");
+        mDarkPref.setOnPreferenceChangeListener(this::onDarkChange);
+        setDarkStyleEnabled(mInterface.getGlobalStyle());
 
         Preference automagic = findPreference("style_automagic");
         automagic.setOnPreferenceClickListener(p -> onAutomagicClick());
@@ -276,8 +276,14 @@ public class StylePreferences extends SettingsPreferenceFragment {
         // selection dialog to be dismissed gracefully
         new Handler().postDelayed(() -> mInterface.setGlobalStyle(value, mPackageName), 500);
 
+        setDarkStyleEnabled(value);
         setStyleIcon(value);
+
         return true;
+    }
+
+    private void setDarkStyleEnabled(int value) {
+        mDarkPref.setEnabled(value != StyleInterface.STYLE_GLOBAL_LIGHT);
     }
 
     private void setStyleIcon(int value) {


### PR DESCRIPTION
* If light design is chosen it doesn't make sense to choose the preferred
  dark mode
* Disable the preference in that case

Change-Id: I0ef64afe91abd52572906c3eb280fec2a4592cad