### PR TITLE
LineageParts: Allow brightness control for segmented LEDs

### DIFF
--- a/src/org/lineageos/lineageparts/notificationlight/BatteryLightSettings.java
+++ b/src/org/lineageos/lineageparts/notificationlight/BatteryLightSettings.java
@@ -149,7 +149,7 @@ public class BatteryLightSettings extends SettingsPreferenceFragment implements
         }
 
         // Remove battery LED brightness controls if we can't support them.
-        if (segmentedBatteryLed || (!mMultiColorLed && !mHALAdjustableBrightness)) {
+        if (!mMultiColorLed && !mHALAdjustableBrightness) {
             prefSet.removePreference(prefSet.findPreference(BRIGHTNESS_SECTION));
         }
 


### PR DESCRIPTION
* The sdk now supports control of non-RGB segmented battery lights,
  and RGB ones already could support it via scaling RGB values

Change-Id: I834134e82a86d396e77b4eca752559c554609776