### PR TITLE
Move the rotation setting to the "normal" SettingsProvider

### DIFF
--- a/src/org/lineageos/lineageparts/hardware/DisplayRotation.java
+++ b/src/org/lineageos/lineageparts/hardware/DisplayRotation.java
@@ -27,8 +27,6 @@ import android.support.v7.preference.PreferenceScreen;
 
 import com.android.internal.view.RotationPolicy;
 
-import lineageos.providers.LineageSettings;
-
 import org.lineageos.lineageparts.R;
 import org.lineageos.lineageparts.SettingsPreferenceFragment;
 
@@ -69,8 +67,8 @@ public class DisplayRotation extends SettingsPreferenceFragment {
         mRotation180Pref = (CheckBoxPreference) prefSet.findPreference(ROTATION_180_PREF);
         mRotation270Pref = (CheckBoxPreference) prefSet.findPreference(ROTATION_270_PREF);
 
-        int mode = LineageSettings.System.getInt(getContentResolver(),
-                LineageSettings.System.ACCELEROMETER_ROTATION_ANGLES,
+        int mode = Settings.System.getInt(getContentResolver(),
+                Settings.System.ACCELEROMETER_ROTATION_ANGLES,
                 ROTATION_0_MODE | ROTATION_90_MODE | ROTATION_270_MODE);
 
         mRotation0Pref.setChecked((mode & ROTATION_0_MODE) != 0);
@@ -132,8 +130,8 @@ public class DisplayRotation extends SettingsPreferenceFragment {
                 mode |= ROTATION_0_MODE;
                 mRotation0Pref.setChecked(true);
             }
-            LineageSettings.System.putInt(getActivity().getContentResolver(),
-                    LineageSettings.System.ACCELEROMETER_ROTATION_ANGLES, mode);
+            Settings.System.putInt(getActivity().getContentResolver(),
+                    Settings.System.ACCELEROMETER_ROTATION_ANGLES, mode);
             return true;
         }
 


### PR DESCRIPTION
ACCELEROMETER_ROTATION_ANGLES and the attached setting needed
to move back to the normal SettingsProvider, or else we could
not query it from inside fw/b (where RotationPolicy is located)

Change-Id: Id3c0e873fadde38fc7ebe2e3b8a2bc94aa45b44b
Fixes: BUGBASH-2042