### PR TITLE
PrivacyGuard: Resolve error message hardcoded white color

### DIFF
--- a/res/layout/privacy_guard_manager.xml
+++ b/res/layout/privacy_guard_manager.xml
@@ -29,7 +29,7 @@
         android:layout_marginTop="20dip"
         android:layout_gravity="center"
         android:gravity="center_horizontal"
-        android:textColor="@android:color/white"
+        android:textColor="?android:attr/textColorPrimary"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:visibility="gone" />
     <FrameLayout


### PR DESCRIPTION
 * In light theme, the "No apps are installed" error message
    is written in white over white instead of the primary color

Change-Id: If99054eeb5f22a51a384472f24b8976172716d62