### PR TITLE
LineageParts: Remove unavailable entries from search

### DIFF
--- a/src/org/lineageos/lineageparts/search/LineagePartsSearchIndexablesProvider.java
+++ b/src/org/lineageos/lineageparts/search/LineagePartsSearchIndexablesProvider.java
@@ -79,7 +79,7 @@ public class LineagePartsSearchIndexablesProvider extends SearchIndexablesProvid
         // from parts_catalog.xml for indexing
         for (String key : keys) {
             PartInfo i = PartsList.get(getContext()).getPartInfo(key);
-            if (i == null || i.getXmlRes() <= 0) {
+            if (i == null || i.getXmlRes() <= 0 || !i.isAvailable()) {
                 continue;
             }
 
@@ -106,7 +106,7 @@ public class LineagePartsSearchIndexablesProvider extends SearchIndexablesProvid
         // which don't have an associated XML resource
         for (String key : keys) {
             PartInfo i = PartsList.get(getContext()).getPartInfo(key);
-            if (i == null) {
+            if (i == null || !i.isAvailable()) {
                 continue;
             }
 
@@ -167,7 +167,7 @@ public class LineagePartsSearchIndexablesProvider extends SearchIndexablesProvid
 
         for (String key : keys) {
             PartInfo i = PartsList.get(getContext()).getPartInfo(key);
-            if (i == null) {
+            if (i == null || !i.isAvailable()) {
                 continue;
             }
 


### PR DESCRIPTION
* By checking isAvailable() before adding an entry to the provider
  we can make sure removed preferences are not visible in search

Change-Id: I05465dbaed9055423a495ef91ce0e352ff8878ca