### PR TITLE
LineageParts: Discard all invalid bits when setting TRUST_WARNINGS value

### DIFF
--- a/src/org/lineageos/lineageparts/trust/TrustPreferences.java
+++ b/src/org/lineageos/lineageparts/trust/TrustPreferences.java
@@ -230,7 +230,8 @@ public class TrustPreferences extends SettingsPreferenceFragment {
                 LineageSettings.Secure.TRUST_WARNINGS, TrustInterface.TRUST_WARN_MAX_VALUE);
         int newValue = value ? (original | feature) : (original & ~feature);
         boolean success = LineageSettings.Secure.putInt(getContext().getContentResolver(),
-                LineageSettings.Secure.TRUST_WARNINGS, newValue);
+                LineageSettings.Secure.TRUST_WARNINGS,
+                newValue & TrustInterface.TRUST_WARN_MAX_VALUE);
         if (success && !value) {
             mInterface.removeNotificationForFeature(feature);
         }


### PR DESCRIPTION
Test: adb shell settings --lineage put secure trust_warnings 3
      then try to change the preference in settings.
Fixes: https://gitlab.com/LineageOS/issues/android/-/issues/2435
Change-Id: Ieda259513fb51380ffb3216f33353f51c23f8ddc